### PR TITLE
Add FluidInference/FluidAudio 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1108,3 +1108,4 @@ A curated list of awesome Swift frameworks, libraries and software.
 * [llvm-swift/LLVMSwift](https://github.com/llvm-swift/LLVMSwift) - A Swift wrapper for the LLVM C API (version 11.0)
 * [Cosmo/Clippy](https://github.com/Cosmo/Clippy) - 📎💬🎉 Clippy from Microsoft Office is back and runs on macOS! Written in Swift.
 * [utahiosmac/Marshal](https://github.com/utahiosmac/Marshal) - Marshaling the typeless wild west of [String: Any]
+* [FluidInference/FluidAudio](https://github.com/FluidInference/FluidAudio) - Frontier CoreML audio models in your apps — text-to-speech, speech-to-text, voice activity detection, and speaker diarization. In Swift, powered by SOTA open source.


### PR DESCRIPTION
- This PR adds FluidInference/FluidAudio to the awesome Swift list.
- FluidAudio brings frontier CoreML audio models to Swift apps: text-to- speech, speech-to-text, voice activity detection, and speaker diarization
- Repository: https://github.com/FluidInference/FluidAudio
- License: Apache-2.0
- Platforms: iOS, macOS (CoreML/AVFoundation)